### PR TITLE
Fix video stream not starting at 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,11 +178,6 @@ impl Encoder {
                   width as usize * 3,
                   height as usize);
         }
-
-        unsafe {
-            (*self.frame).pts +=
-                ffmpeg_sys::av_rescale_q(1, (*self.context).time_base, (*self.video_st).time_base);
-            self.curr_frame_index += self.curr_frame_index;
         }
 
         unsafe {
@@ -248,6 +243,12 @@ impl Encoder {
                 let _ = ffmpeg_sys::av_interleaved_write_frame(self.format_context, &mut pkt);
                 ffmpeg_sys::av_free_packet(&mut pkt);
             }
+        }
+
+        unsafe {
+            (*self.frame).pts +=
+                ffmpeg_sys::av_rescale_q(1, (*self.context).time_base, (*self.video_st).time_base);
+            self.curr_frame_index += self.curr_frame_index;
         }
     }
 


### PR DESCRIPTION
The pts was increased before the frame was encoded.